### PR TITLE
add rplacecdn.destiny.gg workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: Deploy image to rplacecdn.destiny.gg
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    name: Deploy Overlay to R2
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/Checkout@v2
+
+      - name: Deploy to Cloudflare R2
+        run: aws s3 sync ./dgg-place-template-1.png s3://rplacecdn/dgg-place-template-1.png --endpoint-url https://883bb318ad59e2211a4acb9610074d91.r2.cloudflarestorage.com --delete
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_R2_SECRET_ACCESS_KEY }}
+          AWS_REGION: auto


### PR DESCRIPTION
Adds a CI job that on push to `master` the `dgg-place-template-1.png` file is published to https://rplacecdn.destiny.gg/dgg-place-template-1.png